### PR TITLE
Trying fixes raise InstallationError on Heroku

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ cloudinary==1.20.0
 dj-database-url==0.5.0
 Django==3.0.3
 django-bootstrap-form==3.4
-git+git://github.com/tiagocordeiro/django-cloudinary-storage@Django3Support
+-e git://github.com/tiagocordeiro/django-cloudinary-storage.git@Django3Support#egg=django-cloudinary-storage
 django-crispy-forms==1.8.1
 django-heroku==0.3.1
 gunicorn==20.0.4


### PR DESCRIPTION
this is an excerpt from the heroku logs
```
...
pip._vendor.pyparsing.ParseException: Expected stringEnd, found '+'  (at char 3), (line:1, col:4)
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/app/.heroku/python/lib/python3.8/site-packages/pip/req/req_install.py", line 82, in __init__
    req = Requirement(req)
  File "/app/.heroku/python/lib/python3.8/site-packages/pip/_vendor/packaging/requirements.py", line 100, in __init__
    raise InvalidRequirement(
pip._vendor.packaging.requirements.InvalidRequirement: Parse error at "'+git://g'": Expected stringEnd
During handling of the above exception, another exception occurred:
...
pip.exceptions.InstallationError: Invalid requirement: 'git+git://github.com/tiagocordeiro/django-cloudinary-storage@Django3Support'
It looks like a path. Does it exist ?
...
```